### PR TITLE
Adding peripheral layout mode.

### DIFF
--- a/src/ui/Layout.cpp
+++ b/src/ui/Layout.cpp
@@ -62,24 +62,38 @@ void ui::LinearLayout::layout( View *view )
 	} );
 
 	// Update layout based on selected mode and primary axis.
+	size_t index = 0;
 	float offset = mMargin.getUpperLeft()[axis];
+	float negativeOffset = containerSize[axis] - mMargin.getLowerRight()[axis];
 	for( auto &subview : subviews ) {
-		if( mMode == Mode::DISTRIBUTE ) {
-			offset += ( containerSizeMinusMargins - subviewsTotal ) / float( subviews.size() + 1 );
+		if( mMode == Mode::INCREMENT ) {
+			updateAxisPos( subview, offset, axis );
+			offset += subview->getSize()[axis] + mPadding;
+		}
+		else if( mMode == Mode::DISTRIBUTE ) {
+			offset += (containerSizeMinusMargins - subviewsTotal) / float( subviews.size() + 1 );
 			updateAxisPos( subview, offset, axis );
 			offset += subview->getSize()[axis];
 		}
 		else if( mMode == Mode::FILL ) {
 			vec2 size = subview->getSize();
-			size[axis] = ( containerSizeMinusMargins - paddingTotal ) / float( subviews.size() );
+			size[axis] = (containerSizeMinusMargins - paddingTotal) / float( subviews.size() );
 			subview->setSize( size );
 			updateAxisPos( subview, offset, axis );
 			offset += subview->getSize()[axis] + mPadding;
 		}
-		else {
-			updateAxisPos( subview, offset, axis );
-			offset += subview->getSize()[axis] + mPadding;
+		else if( mMode == Mode::PERIPHERAL ) {
+			if( index < glm::ceil( 0.5f * subviews.size() ) ) {
+				updateAxisPos( subview, offset, axis );
+				offset += subview->getSize()[axis] + mPadding;
+			}
+			else {
+				negativeOffset -= subview->getSize()[axis];
+				updateAxisPos( subview, negativeOffset, axis );
+				negativeOffset -= mPadding;
+			}
 		}
+		++index;
 	}
 
 	// Update alignment of all subviews on secondary axis.

--- a/src/ui/Layout.cpp
+++ b/src/ui/Layout.cpp
@@ -71,13 +71,13 @@ void ui::LinearLayout::layout( View *view )
 			offset += subview->getSize()[axis] + mPadding;
 		}
 		else if( mMode == Mode::DISTRIBUTE ) {
-			offset += (containerSizeMinusMargins - subviewsTotal) / float( subviews.size() + 1 );
+			offset += ( containerSizeMinusMargins - subviewsTotal ) / float( subviews.size() + 1 );
 			updateAxisPos( subview, offset, axis );
 			offset += subview->getSize()[axis];
 		}
 		else if( mMode == Mode::FILL ) {
 			vec2 size = subview->getSize();
-			size[axis] = (containerSizeMinusMargins - paddingTotal) / float( subviews.size() );
+			size[axis] = ( containerSizeMinusMargins - paddingTotal ) / float( subviews.size() );
 			subview->setSize( size );
 			updateAxisPos( subview, offset, axis );
 			offset += subview->getSize()[axis] + mPadding;

--- a/src/ui/Layout.h
+++ b/src/ui/Layout.h
@@ -64,6 +64,7 @@ public:
 		INCREMENT = 0, //! Each successive View is placed after the previous one + margin
 		FILL, //! Spreads and expands subviews, overriding each subview's size.
 		DISTRIBUTE, //! Spreads subviews equally based on their center. Ignores padding.
+		PERIPHERAL, //! Stacks subviews on each side.
 		NUM_MODES
 	};
 

--- a/test/src/LayoutTests.cpp
+++ b/test/src/LayoutTests.cpp
@@ -54,10 +54,10 @@ void LayoutTests::addLabels( const ui::ViewRef &view, size_t count )
 void LayoutTests::layout()
 {
 	mHorizontalGroupView->setPos( vec2( 40, 40 ) );
-	mHorizontalGroupView->setSize( vec2( 800, 80 ) );
+	mHorizontalGroupView->setSize( vec2( 800, 100 ) );
 
-	mVerticalGroupView->setPos( vec2( 40, 140 ) );
-	mVerticalGroupView->setSize( vec2( 300, 300 ) );
+	mVerticalGroupView->setPos( vec2( 40, 180 ) );
+	mVerticalGroupView->setSize( vec2( 300, 400 ) );
 }
 
 bool LayoutTests::keyDown( ci::app::KeyEvent &event )


### PR DESCRIPTION
![peripheral_mode](https://cloud.githubusercontent.com/assets/326019/19572792/a94d89d4-96d1-11e6-9c1e-c9ef6ec4e5a8.png)

I increased the parent view bounds back, just because it shows the different modes and alignments more clearly.
