### PR TITLE
Framebuffer improvements: resizing by 1.5x

### DIFF
--- a/src/ui/Filter.cpp
+++ b/src/ui/Filter.cpp
@@ -168,7 +168,7 @@ Filter::Pass::~Pass()
 	// temporary: marking FrameBuffer as unused once Pass is destroyed because it is the sole owner
 	// TODO: remove this once caching is fixed
 	if( mFrameBuffer )
-		mFrameBuffer->mInUse = false;
+		mFrameBuffer->setInUse( false );
 #endif
 }
 

--- a/src/ui/Filter.cpp
+++ b/src/ui/Filter.cpp
@@ -231,6 +231,9 @@ void FilterBlur::process( ui::Renderer *ren, const ui::Filter::Pass &pass )
 		tex = getPassColorTexture( 0 );
 	}
 
+	// the shader varies the sample offset from -10 to 10, so bring it into 'pixel space' by dividing by 10
+	sampleOffset *= 0.1f;
+
 	gl::ScopedGlslProg glslScope( mGlsl );
 	mGlsl->uniform( "uSampleOffset", sampleOffset );
 

--- a/src/ui/Filter.h
+++ b/src/ui/Filter.h
@@ -112,7 +112,7 @@ public:
 private:
 	ci::gl::GlslProgRef	mGlsl;
 
-	ci::vec2	mBlurPixels = ci::vec2( 1 );
+	ci::vec2	mBlurPixels = ci::vec2( 3 );
 };
 
 class FilterDropShadow : public ui::Filter {

--- a/src/ui/Layer.cpp
+++ b/src/ui/Layer.cpp
@@ -149,12 +149,16 @@ void Layer::updateView( View *view )
 	view->clearViewsMarkedForRemoval();
 }
 
+// rules for when we need a new main RenderBuffer:
+// 1. We don't have one already
+// 2. The one we have is currently in use (being rendered to)
+// 3. The one we have isn't large enough (a View was resized)
 void Layer::draw( Renderer *ren )
 {
-	// acquire necessary FrameBuffers. TODO: setup Filter framebuffers here too?
 	if( mRootView->mRendersToFrameBuffer ) {
 		ivec2 renderSize = ivec2( mRenderBounds.getSize() );
-		if( ! mFrameBuffer || ! mFrameBuffer->isUsable() || mFrameBuffer->getSize().x < renderSize.x || mFrameBuffer->getSize().y < renderSize.y ) {
+		if( ! mFrameBuffer || mFrameBuffer->isInUse() || mFrameBuffer->getSize().x < renderSize.x || mFrameBuffer->getSize().y < renderSize.y ) {
+			// acquire necessary FrameBuffers. TODO: setup Filter framebuffers here too?
 			mFrameBuffer = ren->getFrameBuffer( renderSize );
 			LOG_LAYER( "aquired main FrameBuffer for view '" << mRootView->getName() << "', size: " << mFrameBuffer->getSize()
 			           << "', mRenderBounds: " << mRenderBounds << ", view bounds:" << mRootView->getBounds() );

--- a/src/ui/Layer.cpp
+++ b/src/ui/Layer.cpp
@@ -159,6 +159,7 @@ void Layer::draw( Renderer *ren )
 			LOG_LAYER( "aquired FrameBuffer for view '" << mRootView->getName() << "', size: " << mFrameBuffer->getSize()
 			           << "', mFrameBufferBounds: " << mFrameBufferBounds << ", view bounds:" << mRootView->getBounds() );
 
+			mFrameBuffer->setInUse( true ); // note: only so that the following LOG_LAYER prints correctly, this will be marked in use during the pushFrameBuffer()
 			LOG_LAYER( "current frame buffers:\n" << ren->printCurrentFrameBuffersToString() );
 		}
 

--- a/src/ui/Layer.cpp
+++ b/src/ui/Layer.cpp
@@ -57,10 +57,11 @@ Layer::~Layer()
 {
 	LOG_LAYER( hex << this << dec );
 
+#if ! defined( UI_FRAMEBUFFER_CACHING_ENABLED )
 	// temporary: marking FrameBuffer as unused once Layer is destroyed because it is the sole owner
-	// TODO: remove this once caching is fixed
 	if( mFrameBuffer )
-		mFrameBuffer->mInUse = false;
+		mFrameBuffer->setInUse( false );
+#endif
 }
 
 float Layer::getAlpha() const
@@ -231,7 +232,7 @@ void Layer::drawView( View *view, Renderer *ren )
 
 void Layer::processFilters( Renderer *ren, const FrameBufferRef &renderFrameBuffer )
 {
-	renderFrameBuffer->mInUse = true;
+	renderFrameBuffer->setInUse( true );
 
 	// call configure() for any Filters, updating its Pass information
 	for( auto &filter : mRootView->mFilters ) {
@@ -253,7 +254,7 @@ void Layer::processFilters( Renderer *ren, const FrameBufferRef &renderFrameBuff
 
 				// TODO: think of a better way to determine a FrameBuffer is already in use during this tree draw
 				// - with this, the FrameBuffer can't be used in any other part of the draw hierarchy
-				pass.mFrameBuffer->mInUse = true;
+				pass.mFrameBuffer->setInUse( true );
 
 				LOG_LAYER( "current frame buffers:\n" << ren->printCurrentFrameBuffersToString() );
 			}
@@ -280,9 +281,9 @@ void Layer::processFilters( Renderer *ren, const FrameBufferRef &renderFrameBuff
 
 	mFiltersNeedConfiguration = false;
 
-#ifdef UI_FRAMEBUFFER_CACHING_ENABLED
+#if defined( UI_FRAMEBUFFER_CACHING_ENABLED )
 	// TODO: remove, see above TODO in filter processing loop
-	renderFrameBuffer->mInUse = false;
+	renderFrameBuffer->setInUse( false );
 #endif
 }
 

--- a/src/ui/Layer.h
+++ b/src/ui/Layer.h
@@ -68,7 +68,7 @@ class Layer : public std::enable_shared_from_this<Layer> {
 	View*           mRootView;
 	Graph*          mGraph;
 	FrameBufferRef	mFrameBuffer;
-	ci::Rectf       mFrameBufferBounds = ci::Rectf::zero();
+	ci::Rectf       mRenderBounds = ci::Rectf::zero();
 
 	bool			mFiltersNeedConfiguration = false;
 	bool            mShouldRemove = false;

--- a/src/ui/Renderer.cpp
+++ b/src/ui/Renderer.cpp
@@ -127,16 +127,6 @@ ivec2 FrameBuffer::getSize() const
 	return mFbo->getSize();
 }
 
-bool FrameBuffer::isUsable() const
-{
-#if UI_FRAMEBUFFER_CACHING_ENABLED
-	//return ! mDiscarded && ! mInUse;
-	return ! mInUse;
-#else
-	return ! mDiscarded;
-#endif
-}
-
 void FrameBuffer::setInUse( bool inUse )
 {
 	mInUse = inUse;

--- a/src/ui/Renderer.cpp
+++ b/src/ui/Renderer.cpp
@@ -125,6 +125,11 @@ bool FrameBuffer::isUsable() const
 #endif
 }
 
+void FrameBuffer::setInUse( bool inUse )
+{
+	mInUse = inUse;
+}
+
 ImageSourceRef FrameBuffer::createImageSource() const
 {
 	return mFbo->getColorTexture()->createSource();
@@ -250,7 +255,7 @@ FrameBufferRef Renderer::getFrameBuffer( const ci::ivec2 &size )
 
 	auto format = FrameBuffer::Format().size( size );
 	auto result = make_shared<FrameBuffer>( format );
-	result->mInUse = true; // always in use when caching is disabled
+	result->setInUse( true ); // always in use when caching is disabled
 	mFrameBufferCache.push_back( result );
 #endif
 
@@ -267,14 +272,14 @@ void Renderer::clearUnusedFrameBuffers()
 
 void Renderer::pushFrameBuffer( const FrameBufferRef &frameBuffer )
 {
-	frameBuffer->mInUse = true;
+	frameBuffer->setInUse( true );
 	gl::context()->pushFramebuffer( frameBuffer->mFbo );
 }
 
 void Renderer::popFrameBuffer( const FrameBufferRef &frameBuffer )
 {
 #if UI_FRAMEBUFFER_CACHING_ENABLED
-	frameBuffer->mInUse = false;
+	frameBuffer->setInUse( false );
 #endif
 	gl::context()->popFramebuffer();
 }
@@ -286,7 +291,7 @@ std::string Renderer::printCurrentFrameBuffersToString() const
 	for( size_t i = 0; i < mFrameBufferCache.size(); i++ ) {
 		const auto &frameBuffer = mFrameBufferCache[i];
 		s << "[" << i << "] " << hex << frameBuffer.get() << dec;
-		s << ": in use: " << frameBuffer->mInUse;
+		s << ": in use: " << frameBuffer->isInUse();
 		s << ", discarded: " << frameBuffer->mDiscarded;
 		s << ", ref count: " << frameBuffer.use_count();
 		s << ", size: " << frameBuffer->getSize();

--- a/src/ui/Renderer.cpp
+++ b/src/ui/Renderer.cpp
@@ -236,19 +236,19 @@ FrameBufferRef Renderer::getFrameBuffer( const ci::ivec2 &size )
 		}
 	}
 
-	auto format = FrameBuffer::Format().size( size );
-
 	// If a FrameBuffer is available but not large enough, resize it.
+	// - the size is increased to 1.5x the requested size, in order to prevent things that are animating larger from causing too many reallocations.
 	if( availableIt != mFrameBufferCache.end()  ) {
-		ivec2 nextSize = size;
-		LOG_FRAMEBUFFER( "\t- resizing FrameBuffer : " << hex << availableIt->get() << dec << ", from size: " << (*availableIt)->getSize() << " to: " << nextSize );
+		const float resizeFactor = 1.5f;
+		ivec2 nextSize = glm::ceil( vec2( size ) * resizeFactor );
+		LOG_FRAMEBUFFER( "\t- resizing FrameBuffer : " << hex << availableIt->get() << dec << ", from size: " << (*availableIt)->getSize() << " to: " << nextSize << " (requested size: " << size << ")" );
 
-		(*availableIt)->updateFormat( format );
+		(*availableIt)->updateFormat( FrameBuffer::Format().size( nextSize ) );
 		return *availableIt;
 	}
 
 	// None were available, make a new one.
-	auto result = make_shared<FrameBuffer>( format );
+	auto result = make_shared<FrameBuffer>( FrameBuffer::Format().size( size ) );
 	mFrameBufferCache.push_back( result );
 	LOG_FRAMEBUFFER( "created FrameBuffer " << hex << result.get() << dec << ", size: " << result->getSize() );
 

--- a/src/ui/Renderer.cpp
+++ b/src/ui/Renderer.cpp
@@ -94,8 +94,6 @@ bool FrameBuffer::Format::operator==(const Format &other) const
 
 FrameBuffer::FrameBuffer( const Format &format )
 {
-	LOG_FRAMEBUFFER( "creating FrameBuffer " << hex << this << dec << ", size: " << format.mSize );
-
 	auto fboFormat = gl::Fbo::Format();
 	fboFormat.colorTexture(
 			gl::Texture2d::Format()
@@ -237,11 +235,12 @@ FrameBufferRef Renderer::getFrameBuffer( const ci::ivec2 &size )
 	// Make a new one.
 	auto format = FrameBuffer::Format().size( size );
 	auto result = make_shared<FrameBuffer>( format );
+	LOG_FRAMEBUFFER( "created FrameBuffer " << hex << result.get() << dec << ", size: " << result->getSize() );
 
 	// Replace the largest unbound FrameBuffer, or push another one if one wasn't available
 	if( availableFrameBufferIt != mFrameBufferCache.end()  ) {
 		auto old = *availableFrameBufferIt;
-		LOG_FRAMEBUFFER( "discarding FrameBuffer : " << hex << old.get() << dec << ", size: " << old->getSize() );
+		LOG_FRAMEBUFFER( "\t- discarding FrameBuffer : " << hex << old.get() << dec << ", size: " << old->getSize() );
 		old->mDiscarded = true;
 		*availableFrameBufferIt = result;
 	}
@@ -295,7 +294,9 @@ std::string Renderer::printCurrentFrameBuffersToString() const
 		s << ", discarded: " << frameBuffer->mDiscarded;
 		s << ", ref count: " << frameBuffer.use_count();
 		s << ", size: " << frameBuffer->getSize();
-		s << endl;
+
+		if( i < mFrameBufferCache.size() - 1 )
+			s << endl;
 	}
 
 	return s.str();

--- a/src/ui/Renderer.h
+++ b/src/ui/Renderer.h
@@ -84,8 +84,10 @@ class FrameBuffer {
 	ci::gl::FboRef		mFbo; // TODO: make private
 
 private:
+	//! Updates the internal FBO to match \a format.
+	void updateFormat( const Format &format );
+
 	bool                mInUse = false;
-	bool				mDiscarded = false;
 
 	friend class Renderer;
 };

--- a/src/ui/Renderer.h
+++ b/src/ui/Renderer.h
@@ -73,7 +73,6 @@ class FrameBuffer {
 	int         getWidth() const { return getSize().x; }
 	int         getHeight() const { return getSize().y; }
 	bool        isInUse() const { return mInUse; }
-	bool		isUsable() const;
 	void		setInUse( bool inUse );
 
 	ci::ImageSourceRef  createImageSource() const;

--- a/src/ui/Renderer.h
+++ b/src/ui/Renderer.h
@@ -74,6 +74,7 @@ class FrameBuffer {
 	int         getHeight() const { return getSize().y; }
 	bool        isInUse() const { return mInUse; }
 	bool		isUsable() const;
+	void		setInUse( bool inUse );
 
 	ci::ImageSourceRef  createImageSource() const;
 
@@ -82,9 +83,8 @@ class FrameBuffer {
 
 	ci::gl::FboRef		mFbo; // TODO: make private
 
-	bool                mInUse = false; // TODO: make private
-
 private:
+	bool                mInUse = false;
 	bool				mDiscarded = false;
 
 	friend class Renderer;

--- a/src/ui/TextManager.cpp
+++ b/src/ui/TextManager.cpp
@@ -105,7 +105,10 @@ TextRef TextManager::loadTextImplAsync( FontFace face, float size )
 
 std::string TextManager::getFontName( FontFace face ) const
 {
-	return "Arial";
+	if( face == FontFace::BOLD )
+		return "Arial Bold";
+	else
+		return "Arial";
 }
 
 // ----------------------------------------------------------------------------------------------------

--- a/test/src/CompositingTest.cpp
+++ b/test/src/CompositingTest.cpp
@@ -12,6 +12,7 @@ using namespace ci;
 using namespace mason;
 
 const float PADDING = 50;
+const vec2 LABEL_SIZE = { 200, 200 };
 
 CompositingTest::CompositingTest()
 	: SuiteView()
@@ -59,42 +60,61 @@ CompositingTest::CompositingTest()
 
 	Rectf sliderRect =  Rectf( 10, 10, 150, 40 );
 	{
-		auto alphaSlider = make_shared<ui::HSlider>( sliderRect );
-		alphaSlider->setTitle( "container alpha" );
-		alphaSlider->setValue( mContainerView->getAlpha() );
-		alphaSlider->getBackground()->setColor( Color::gray( 0.15f ) );
-		auto alphaSliderPtr = alphaSlider.get(); // avoiding cyclical strong reference, slider is also owned by parent view
-		alphaSlider->getSignalValueChanged().connect( [this, alphaSliderPtr] {
+		auto slider = make_shared<ui::HSlider>( sliderRect );
+		slider->setTitle( "container alpha" );
+		slider->setValue( mContainerView->getAlpha() );
+		slider->getBackground()->setColor( Color::gray( 0.15f ) );
+		auto alphaSliderPtr = slider.get(); // avoiding cyclical strong reference, slider is also owned by parent view
+		slider->getSignalValueChanged().connect( [this, alphaSliderPtr] {
 			mContainerView->setAlpha( alphaSliderPtr->getValue() );
 		} );
 
-		mContainerView->addSubview( alphaSlider );
+		mContainerView->addSubview( slider );
 	}
 	sliderRect += vec2( 0, 40 );
 	{
-		auto alphaSlider = make_shared<ui::HSlider>( sliderRect );
-		alphaSlider->setTitle( "C alpha" );
-		alphaSlider->setValue( mLabelC->getAlpha() );
-		alphaSlider->getBackground()->setColor( Color::gray( 0.15f ) );
-		auto alphaSliderPtr = alphaSlider.get(); // avoiding cyclical strong reference, slider is also owned by parent view
-		alphaSlider->getSignalValueChanged().connect( [this, alphaSliderPtr] {
+		auto slider = make_shared<ui::HSlider>( sliderRect );
+		slider->setTitle( "C alpha" );
+		slider->setValue( mLabelC->getAlpha() );
+		slider->getBackground()->setColor( Color::gray( 0.15f ) );
+		auto alphaSliderPtr = slider.get(); // avoiding cyclical strong reference, slider is also owned by parent view
+		slider->getSignalValueChanged().connect( [this, alphaSliderPtr] {
 			mLabelC->setAlpha( alphaSliderPtr->getValue() );
 		} );
 
-		mContainerView->addSubview( alphaSlider );
+		mContainerView->addSubview( slider );
 	}
 	sliderRect += vec2( 0, 40 );
 	{
-		auto alphaSlider = make_shared<ui::HSlider>( sliderRect );
-		alphaSlider->setTitle( "D alpha" );
-		alphaSlider->setValue( mLabelD->getAlpha() );
-		alphaSlider->getBackground()->setColor( Color::gray( 0.15f ) );
-		auto alphaSliderPtr = alphaSlider.get(); // avoiding cyclical strong reference, slider is also owned by parent view
-		alphaSlider->getSignalValueChanged().connect( [this, alphaSliderPtr] {
+		auto slider = make_shared<ui::HSlider>( sliderRect );
+		slider->setTitle( "D alpha" );
+		slider->setValue( mLabelD->getAlpha() );
+		slider->getBackground()->setColor( Color::gray( 0.15f ) );
+		auto alphaSliderPtr = slider.get(); // avoiding cyclical strong reference, slider is also owned by parent view
+		slider->getSignalValueChanged().connect( [this, alphaSliderPtr] {
 			mLabelD->setAlpha( alphaSliderPtr->getValue() );
 		} );
 
-		mContainerView->addSubview( alphaSlider );
+		mContainerView->addSubview( slider );
+	}
+	sliderRect += vec2( 0, 40 );
+	{
+		auto slider = make_shared<ui::HSlider>( sliderRect );
+		slider->setTitle( "C scale" );
+		slider->setValue( 1 );
+		slider->setMin( 0.1f );
+		slider->setMax( 3 );
+		slider->getBackground()->setColor( Color::gray( 0.15f ) );
+		auto alphaSliderPtr = slider.get(); // avoiding cyclical strong reference, slider is also owned by parent view
+		slider->getSignalValueChanged().connect( [this, alphaSliderPtr] {
+			vec2 c = mLabelC->getCenter();
+			vec2 h = ( LABEL_SIZE / 2.0f ) * alphaSliderPtr->getValue();
+			Rectf bounds = Rectf( c.x - h.x, c.y - h.y, c.x + h.x, c.y + h.y );
+			mLabelC->setBounds( bounds );
+			//CI_LOG_I( "set bounds to: " << bounds );
+		} );
+
+		mContainerView->addSubview( slider );
 	}
 
 	mLabelC->addSubview( mLabelD );
@@ -107,15 +127,13 @@ void CompositingTest::layout()
 	mContainerView->setBounds( Rectf( PADDING, PADDING, getWidth() - PADDING, getHeight() - PADDING ) );
 	CI_LOG_I( "mContainerView bounds: " << mContainerView->getBounds() );
 
-	const vec2 labelSize = { 200, 200 };
-
 	mLabelA->setPos( { 200, 100 } );
 	mLabelB->setPos( { 450, 100 } );
 	mLabelC->setPos( { 325, 200 } );
 
-	mLabelA->setSize( labelSize );
-	mLabelB->setSize( labelSize );
-	mLabelC->setSize( labelSize );
+	mLabelA->setSize( LABEL_SIZE );
+	mLabelB->setSize( LABEL_SIZE );
+	mLabelC->setSize( LABEL_SIZE );
 
 	mLabelD->setPos( { 12, 70 } );
 	mLabelD->setSize( vec2( 60, 60 ) );
@@ -147,6 +165,11 @@ bool CompositingTest::keyDown( app::KeyEvent &event )
 		case app::KeyEvent::KEY_o: {
 			float nextBorderWidth = randFloat( 1, 30 );
 			app::timeline().apply( mContainerView->getLineWidthAnim(), nextBorderWidth, 0.6f, EaseOutExpo() );
+			break;
+		}
+		case app::KeyEvent::KEY_s: {
+			vec2 nextLabelSize = LABEL_SIZE * vec2( randFloat( 0.5f, 2.0f ), randFloat( 0.5f, 2.0f ) );
+			app::timeline().apply( mLabelC->animSize(), nextLabelSize, 0.6f, EaseInOutExpo() );
 			break;
 		}
 		default:

--- a/test/src/CompositingTest.cpp
+++ b/test/src/CompositingTest.cpp
@@ -55,9 +55,11 @@ CompositingTest::CompositingTest()
 	mLabelD->setAlignment( ui::TextAlignment::CENTER );
 	mLabelD->setTextColor( Color::white() );
 	mLabelD->getBackground()->setColor( Color( 1, 1, 0 ) );
+	mLabelD->setAlpha( 0.75f );
 
+	Rectf sliderRect =  Rectf( 10, 10, 150, 40 );
 	{
-		auto alphaSlider = make_shared<ui::HSlider>( Rectf( 10, 10, 150, 40 ) );
+		auto alphaSlider = make_shared<ui::HSlider>( sliderRect );
 		alphaSlider->setTitle( "container alpha" );
 		alphaSlider->setValue( mContainerView->getAlpha() );
 		alphaSlider->getBackground()->setColor( Color::gray( 0.15f ) );
@@ -68,14 +70,28 @@ CompositingTest::CompositingTest()
 
 		mContainerView->addSubview( alphaSlider );
 	}
+	sliderRect += vec2( 0, 40 );
 	{
-		auto alphaSlider = make_shared<ui::HSlider>( Rectf( 10, 50, 150, 80 ) );
+		auto alphaSlider = make_shared<ui::HSlider>( sliderRect );
 		alphaSlider->setTitle( "C alpha" );
 		alphaSlider->setValue( mLabelC->getAlpha() );
 		alphaSlider->getBackground()->setColor( Color::gray( 0.15f ) );
 		auto alphaSliderPtr = alphaSlider.get(); // avoiding cyclical strong reference, slider is also owned by parent view
 		alphaSlider->getSignalValueChanged().connect( [this, alphaSliderPtr] {
 			mLabelC->setAlpha( alphaSliderPtr->getValue() );
+		} );
+
+		mContainerView->addSubview( alphaSlider );
+	}
+	sliderRect += vec2( 0, 40 );
+	{
+		auto alphaSlider = make_shared<ui::HSlider>( sliderRect );
+		alphaSlider->setTitle( "D alpha" );
+		alphaSlider->setValue( mLabelD->getAlpha() );
+		alphaSlider->getBackground()->setColor( Color::gray( 0.15f ) );
+		auto alphaSliderPtr = alphaSlider.get(); // avoiding cyclical strong reference, slider is also owned by parent view
+		alphaSlider->getSignalValueChanged().connect( [this, alphaSliderPtr] {
+			mLabelD->setAlpha( alphaSliderPtr->getValue() );
 		} );
 
 		mContainerView->addSubview( alphaSlider );

--- a/test/src/FilterTest.cpp
+++ b/test/src/FilterTest.cpp
@@ -64,13 +64,22 @@ FilterTest::FilterTest()
 	mLabel = make_shared<ui::Label>();
 	mLabel->setText( "T" );
 	mLabel->setLabel( "Label with FilterDropShadow" );
-	mLabel->setFontFace( ui::FontFace::BOLD );
+	mLabel->setFontFace( ui::FontFace::NORMAL );
 	mLabel->setFontSize( 280 );
 	mLabel->setAlignment( ui::TextAlignment::CENTER );
 	mLabel->setTextColor( Color( 0, 0, 0.75f ) );
 
+	mLabelNested = make_shared<ui::Label>();
+	mLabelNested->setText( "PLFF!" );
+	mLabelNested->setLabel( "Label with FilterDropShadow" );
+	mLabelNested->setFontFace( ui::FontFace::BOLD );
+	mLabelNested->setFontSize( 84 );
+	mLabelNested->setAlignment( ui::TextAlignment::CENTER );
+	mLabelNested->setTextColor( Color( 0, 0, 0.75f ) );
+
 	mFilterSinglePass = make_shared<FilterSinglePass>();
 	mFilterBlur = make_shared<ui::FilterBlur>();
+	mFilterBlurNested = make_shared<ui::FilterBlur>();
 	mFilterDropShadow = make_shared<ui::FilterDropShadow>();
 	mFilterDropShadow->setDownsampleFactor( 1 );
 	mFilterDropShadow->setShadowOffset( vec2( -6, 4 ) );
@@ -80,6 +89,7 @@ FilterTest::FilterTest()
 	mImageView->addFilter( mFilterSinglePass );
 	//mImageView->addFilter( mFilterBlur );
 	mLabel->addFilter( mFilterDropShadow );
+	mLabelNested->addFilter( mFilterBlurNested );
 
 	{
 		auto imageBorder = make_shared<ui::StrokedRectView>();
@@ -98,10 +108,10 @@ FilterTest::FilterTest()
 	}
 #endif
 
-	const Color toggleEnabledColor = { 0, 0.2f, 0.6f };
+	const Color toggleEnabledColor = { 0, 0.4f, 0.6f };
 
 	mToggleSinglePass = make_shared<ui::Button>();
-	mToggleSinglePass->setTitle( "enable single pass" );
+	mToggleSinglePass->setTitle( "single pass" );
 	mToggleSinglePass->setAsToggle();
 	mToggleSinglePass->setColor( toggleEnabledColor, ui::Button::State::ENABLED );
 	mToggleSinglePass->setTitleColor( Color::white() );
@@ -121,26 +131,40 @@ FilterTest::FilterTest()
 
 
 	mToggleBlur = make_shared<ui::Button>();
-	mToggleBlur->setTitle( "enable blur" );
+	mToggleBlur->setTitle( "blur" );
 	mToggleBlur->setAsToggle();
 	mToggleBlur->setColor( toggleEnabledColor, ui::Button::State::ENABLED );
 	mToggleBlur->setTitleColor( Color::white() );
 	mToggleBlur->setEnabled( false );
 	mToggleBlur->getSignalReleased().connect( [this] {
+		// swap out the monkey ImageView's Filter for blur (or swap back)
 		if( mToggleBlur->isEnabled() ) {
 			mImageView->removeAllFilters();
-			CI_LOG_I( "-------- adding mFilterBlur --------" );
 			mImageView->addFilter( mFilterBlur );
 			mToggleSinglePass->setEnabled( false );
 		}
 		else {
-			CI_LOG_I( "-------- removing mFilterBlur --------" );
 			mImageView->removeFilter( mFilterBlur );
 		}
 	} );
 
+	mToggleBlurNested = make_shared<ui::Button>();
+	mToggleBlurNested->setTitle( "blur nested" );
+	mToggleBlurNested->setAsToggle();
+	mToggleBlurNested->setColor( toggleEnabledColor, ui::Button::State::ENABLED );
+	mToggleBlurNested->setTitleColor( Color::white() );
+	mToggleBlurNested->setEnabled( true );
+	mToggleBlurNested->getSignalReleased().connect( [this] {
+		// toggle blur on the nested label, within the monkey ImageView
+		if( mToggleBlurNested->isEnabled() )
+			mLabelNested->addFilter( mFilterBlurNested );
+		else
+			mLabelNested->removeAllFilters();
+	} );
+
+
 	mToggleDropShadow = make_shared<ui::Button>();
-	mToggleDropShadow->setTitle( "enable drop shadow" );
+	mToggleDropShadow->setTitle( "drop shadow" );
 	mToggleDropShadow->setAsToggle();
 	mToggleDropShadow->setColor( toggleEnabledColor, ui::Button::State::ENABLED );
 	mToggleDropShadow->setTitleColor( Color::white() );
@@ -162,6 +186,7 @@ FilterTest::FilterTest()
 	mSliderBlur->setValue( mFilterBlur->getBlurPixels().x );
 	mSliderBlur->getSignalValueChanged().connect( [this] {
 		mFilterBlur->setBlurPixels( vec2( mSliderBlur->getValue() ) );
+		mFilterBlurNested->setBlurPixels( vec2( mSliderBlur->getValue() ) );
 	} );
 
 	mSliderDropShadow = make_shared<ui::HSlider>();
@@ -172,10 +197,13 @@ FilterTest::FilterTest()
 		mFilterDropShadow->setBlurPixels( vec2( mSliderDropShadow->getValue() ) );
 	} );
 
+
+	mImageView->addSubview( mLabelNested );
+
 	mContainerView->addSubviews( { 
 		mImageView,
 		mLabel,
-		mToggleSinglePass, mToggleBlur, mToggleDropShadow,
+		mToggleSinglePass, mToggleBlur, mToggleBlurNested, mToggleDropShadow,
 		mSliderBlur, mSliderDropShadow
 	} );
 
@@ -200,6 +228,10 @@ void FilterTest::layout()
 	mToggleBlur->setPos( togglePos );
 	mToggleBlur->setSize( toggleSize );
 
+	togglePos.x += toggleSize.x + controlPadding;
+	mToggleBlurNested->setPos( togglePos );
+	mToggleBlurNested->setSize( toggleSize );
+
 	vec2 sliderPos = { controlPadding, togglePos.y + toggleSize.y + controlPadding }; 
 	vec2 sliderSize = { 210, 40 };
 	mSliderBlur->setPos( sliderPos );
@@ -221,6 +253,10 @@ void FilterTest::layout()
 	const vec2 sizeDiff = { 40, 40 };
 	mLabel->setPos( { togglePos.x, mSliderDropShadow->getBounds().y2 + controlPadding } );
 	mLabel->setSize( vec2( containerBounds.getWidth() - mLabel->getPosX() - controlPadding - sizeDiff.x, mImageView->getHeight() - sizeDiff.y ) );
+
+	// Nested Label with blur filter lives in the ImageView, at the top right
+	mLabelNested->setPos( vec2( 220, 80 ) );
+	mLabelNested->setSize( vec2( 240, 100 ) );
 }
 
 bool FilterTest::keyDown( ci::app::KeyEvent &event )
@@ -239,6 +275,8 @@ void FilterTest::loadGlsl()
 		mGlslBlur = gl::GlslProg::create( app::loadAsset( "glsl/blur.vert" ), app::loadAsset( "glsl/blur.frag" ) );
 		if( mFilterBlur )
 			mFilterBlur->setGlslProg( mGlslBlur );
+		if( mFilterBlurNested )
+			mFilterBlurNested->setGlslProg( mGlslBlur );
 
 		CI_LOG_I( "blur glsl loaded." );
 	}

--- a/test/src/FilterTest.cpp
+++ b/test/src/FilterTest.cpp
@@ -49,7 +49,7 @@ FilterTest::FilterTest()
 	mContainerView->setLabel( "container" );
 
 	mImageView = make_shared<ui::ImageView>();
-	mImageView->setLabel( "ImageView with filter" );
+	mImageView->setLabel( "ImageView" );
 
 	fs::path imageFilePath = app::getAssetPath( "images/monkey_hitchhike.jpg" );
 	try {
@@ -63,7 +63,7 @@ FilterTest::FilterTest()
 
 	mLabel = make_shared<ui::Label>();
 	mLabel->setText( "T" );
-	mLabel->setLabel( "Label with FilterDropShadow" );
+	mLabel->setLabel( "Label T" );
 	mLabel->setFontFace( ui::FontFace::NORMAL );
 	mLabel->setFontSize( 280 );
 	mLabel->setAlignment( ui::TextAlignment::CENTER );
@@ -71,7 +71,7 @@ FilterTest::FilterTest()
 
 	mLabelNested = make_shared<ui::Label>();
 	mLabelNested->setText( "PLFF!" );
-	mLabelNested->setLabel( "Label with FilterDropShadow" );
+	mLabelNested->setLabel( "Nested Label" );
 	mLabelNested->setFontFace( ui::FontFace::BOLD );
 	mLabelNested->setFontSize( 84 );
 	mLabelNested->setAlignment( ui::TextAlignment::CENTER );

--- a/test/src/FilterTest.h
+++ b/test/src/FilterTest.h
@@ -28,14 +28,14 @@ class FilterTest : public ui::SuiteView {
 	void loadGlsl();
 
 	std::shared_ptr<FilterSinglePass>	mFilterSinglePass;
-	ui::FilterBlurRef					mFilterBlur;
+	ui::FilterBlurRef					mFilterBlur, mFilterBlurNested;
 	ui::FilterDropShadowRef				mFilterDropShadow;
 
 	ci::gl::GlslProgRef					mGlslBlur, mGlslDropshadow;
 
 	ui::ViewRef				mContainerView;
 	ui::ImageViewRef        mImageView;
-	ui::ButtonRef			mToggleSinglePass, mToggleBlur, mToggleDropShadow;
+	ui::ButtonRef			mToggleSinglePass, mToggleBlur, mToggleBlurNested, mToggleDropShadow;
 	ui::HSliderRef			mSliderBlur, mSliderDropShadow;
-	ui::LabelRef			mLabel;
+	ui::LabelRef			mLabel, mLabelNested;
 };

--- a/test/src/ViewTestsApp.cpp
+++ b/test/src/ViewTestsApp.cpp
@@ -59,7 +59,7 @@ void ViewTestsApp::setup()
 		CI_LOG_I( "selected test index: " << mTestSuite->getCurrentIndex() << ", key: " << mTestSuite->getCurrentKey() );
 	} );
 
-	mTestSuite->select( 6 );
+	mTestSuite->select( 1 );
 
 	mInfoLabel = make_shared<ui::LabelGrid>();
 	mInfoLabel->setTextColor( Color::white() );

--- a/test/src/ViewTestsApp.cpp
+++ b/test/src/ViewTestsApp.cpp
@@ -20,7 +20,7 @@ using namespace ci;
 using namespace ci::app;
 using namespace std;
 
-const vec2 INFO_ROW_SIZE    = vec2( 200, 20 );
+const vec2 INFO_ROW_SIZE    = vec2( 250, 20 );
 const float PADDING         = 6;
 
 class ViewTestsApp : public App {
@@ -101,7 +101,7 @@ void ViewTestsApp::updateUI()
 	mInfoLabel->setRow( 0, { "fps:",  fmt::format( "{}", getAverageFps() ) } );
 
 	size_t numFrameBuffers = mTestSuite->getGraph()->getRenderer()->getNumFrameBuffersCached();
-	mInfoLabel->setRow( 1, { "num FrameBuffers: ", to_string( numFrameBuffers ) } );
+	mInfoLabel->setRow( 1, { "FrameBuffers: ", to_string( numFrameBuffers ) } );
 
 	if( ! glm::epsilonEqual( INFO_ROW_SIZE.y * mInfoLabel->getNumRows(), mInfoLabel->getHeight(), 0.01f ) )
 		resizeInfoLabel();


### PR DESCRIPTION
No longer discarding a framebuffer when it is available in the cache but not large enough. Instead, resize it to be 1.5x the size requested. Accommodates animation.